### PR TITLE
Update Grunt peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   "author": "Chris Wren",
   "license": "MIT",
   "peerDependencies": {
-    "grunt": "~0.4.1"
+    "grunt": "^0.4.1 || ^1.0.1"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
+    "grunt": "^0.4.1 || ^1.0.1",
     "grunt-release": "~0.5.1",
     "grunt-contrib-jshint": "~0.6.2",
     "matchdep": "~0.1.2",


### PR DESCRIPTION
So this happened:

    npm ERR! peerinvalid The package grunt@1.0.1 does not satisfy its siblings' peerDependencies requirements!

Here's the fix. No other changes required, works fine with Grunt 1.0.1.